### PR TITLE
feat: add library pages and loans service

### DIFF
--- a/src/pages/library/books/requestList.vue
+++ b/src/pages/library/books/requestList.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="container m-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Catálogo de Livros</h1>
+    </div>
+
+    <!-- Filtros -->
+    <div
+      class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4 p-3 border rounded bg-body border-secondary border-opacity-25"
+    >
+      <div class="mb-3 mb-md-0">
+        <label class="d-flex align-items-center gap-2 text-nowrap text-body">
+          Mostrar
+          <select
+            v-model.number="limit"
+            class="form-select form-select-sm w-auto"
+            @change="reload"
+          >
+            <option :value="5">5</option>
+            <option :value="10">10</option>
+            <option :value="25">25</option>
+          </select>
+          por página
+        </label>
+      </div>
+
+      <div class="d-flex gap-2 w-md-auto">
+        <input
+          v-model="q"
+          class="form-control"
+          placeholder="Pesquisar por título, autor ou ISBN..."
+          @keyup.enter="reload"
+        />
+        <button class="btn btn-outline-primary text-nowrap" @click="reload">
+          <i class="bi bi-search me-1"></i> Buscar
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="alert alert-info text-center" role="alert">
+      <div class="spinner-border spinner-border-sm me-2" role="status">
+        <span class="visually-hidden">Carregando...</span>
+      </div>
+      Carregando...
+    </div>
+
+    <!-- Tabela -->
+    <div v-else>
+      <div v-if="!error" class="table-responsive shadow-sm rounded mb-4">
+        <table
+          v-if="books.length"
+          class="table table-striped table-hover align-middle mb-0"
+        >
+          <thead class="table-dark align-middle">
+            <tr>
+              <th scope="col">Título</th>
+              <th scope="col">Editora</th>
+              <th scope="col">Ano</th>
+              <th scope="col">ISBN</th>
+              <th scope="col">Disponíveis</th>
+              <th scope="col" class="text-center">Ação</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="b in books" :key="b.id">
+              <td>
+                <strong>{{ b.title }}</strong>
+                <br />
+                <span class="small text-muted">{{ b.author }}</span>
+              </td>
+              <td>{{ b.publisher || '-' }}</td>
+              <td>{{ b.year }}</td>
+              <td>{{ b.isbn }}</td>
+              <td>
+                <span
+                  :class="[
+                    'badge',
+                    b.available_quantity > 0 ? 'bg-success' : 'bg-danger',
+                  ]"
+                >
+                  {{ b.available_quantity }}
+                </span>
+              </td>
+              <td class="text-center">
+                <button
+                  class="btn btn-sm"
+                  :class="
+                    b.available_quantity > 0
+                      ? 'btn-outline-primary'
+                      : 'btn-outline-secondary disabled'
+                  "
+                  :disabled="b.available_quantity === 0 || loadingLoan"
+                  @click="requestLoan(b.id)"
+                >
+                  <i class="bi bi-journal-arrow-down me-1"></i> Emprestar
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div v-else class="alert alert-warning text-center m-2" role="alert">
+          Nenhum livro encontrado.
+        </div>
+      </div>
+
+      <!-- Paginação -->
+      <div
+        v-if="meta.total && totalPages > 1"
+        class="d-flex justify-content-between align-items-center"
+      >
+        <span class="text-muted"
+          >Página {{ meta.page }} de {{ totalPages }}</span
+        >
+
+        <div class="btn-group" role="group">
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            :disabled="!meta.has_prev"
+            @click="prev"
+          >
+            &laquo; Anterior
+          </button>
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            :disabled="!meta.has_next"
+            @click="next"
+          >
+            Próxima &raquo;
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Erro -->
+    <div v-if="error" class="alert alert-danger mt-4" role="alert">
+      <strong>Erro:</strong> {{ error }}
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref, onMounted, computed } from 'vue'
+  import { BooksService } from '@/services/books.services'
+  import { LoansService } from '@/services/loans.services'
+  import {
+    success as successToast,
+    error as errorToast,
+    confirm as confirmToast,
+  } from '@/composables/useToast'
+
+  const books = ref([])
+  const loading = ref(false)
+  const loadingLoan = ref(false)
+  const error = ref(null)
+
+  const page = ref(1)
+  const limit = ref(10)
+  const q = ref('')
+
+  const meta = ref({
+    total: null,
+    offset: 0,
+    limit: 10,
+  })
+
+  const totalPages = computed(() => meta.value.total_pages || 1)
+
+  async function load() {
+    loading.value = true
+    error.value = null
+    const offset = (page.value - 1) * limit.value
+
+    try {
+      const data = await BooksService.list(offset, limit.value, q.value)
+      books.value = data.books || []
+      meta.value = {
+        total: data.meta?.total ?? books.value.length,
+        page: data.meta?.page ?? page.value,
+        size: data.meta?.size ?? limit.value,
+        total_pages: data.meta?.total_pages ?? 1,
+        has_next: data.meta?.has_next ?? false,
+        has_prev: data.meta?.has_prev ?? false,
+        offset: data.meta?.offset ?? offset,
+      }
+    } catch (err) {
+      console.error('Erro ao carregar livros', err)
+      error.value =
+        err?.response?.data?.detail ||
+        err?.response?.data?.message ||
+        err?.message ||
+        'Erro desconhecido'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function requestLoan(bookId) {
+    const ok = await confirmToast('Deseja solicitar este livro?', {
+      title: 'Solicitar empréstimo',
+    })
+    if (!ok) return
+
+    loadingLoan.value = true
+    try {
+      await LoansService.request(bookId)
+      successToast('Empréstimo solicitado com sucesso!')
+      await load()
+    } catch (err) {
+      console.error(err)
+      errorToast(
+        err?.response?.data?.detail ||
+          err?.response?.data?.message ||
+          'Erro ao solicitar empréstimo',
+      )
+    } finally {
+      loadingLoan.value = false
+    }
+  }
+
+  function reload() {
+    page.value = 1
+    load()
+  }
+
+  function next() {
+    if (meta.value.has_next) {
+      page.value++
+      load()
+    }
+  }
+  function prev() {
+    if (meta.value.has_prev) {
+      page.value--
+      load()
+    }
+  }
+
+  onMounted(() => {
+    load()
+  })
+</script>

--- a/src/pages/library/loans/AdminLoansList.vue
+++ b/src/pages/library/loans/AdminLoansList.vue
@@ -1,0 +1,358 @@
+<template>
+  <div class="container m-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Gestão de Empréstimos</h1>
+    </div>
+
+    <div
+      class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4 p-3 border rounded bg-body border-secondary border-opacity-25"
+    >
+      <div class="mb-3 mb-md-0 d-flex align-items-center gap-2">
+        <label for="statusFilter" class="form-label fw-semibold mb-0"
+          >Filtrar por status:</label
+        >
+        <select
+          id="statusFilter"
+          v-model="statusFilter"
+          class="form-select form-select-sm w-auto"
+          @change="reload"
+        >
+          <option value="">Todos</option>
+          <option value="requested">Solicitado</option>
+          <option value="canceled">Cancelado</option>
+          <option value="borrowed">Emprestado</option>
+          <option value="returned">Devolvido</option>
+          <option value="late">Atrasado</option>
+          <option value="rejected">Rejeitado</option>
+        </select>
+      </div>
+
+      <div class="d-flex align-items-center gap-2">
+        <label for="searchFilter" class="form-label fw-semibold mb-0"
+          >Buscar:</label
+        >
+        <div class="input-group input-group-sm">
+          <input
+            id="searchFilter"
+            v-model="searchFilter"
+            type="text"
+            class="form-control"
+            placeholder="Título, Autor, Usuário"
+            @keyup.enter="reload"
+          />
+          <button class="btn btn-outline-secondary" @click="reload">
+            <i class="bi bi-search"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="loading" class="alert alert-info text-center" role="alert">
+      <div class="spinner-border spinner-border-sm me-2" role="status">
+        <span class="visually-hidden">Carregando...</span>
+      </div>
+      Carregando...
+    </div>
+
+    <div v-else>
+      <div v-if="!error" class="table-responsive shadow-sm rounded mb-4">
+        <table
+          v-if="loans.length"
+          class="table table-striped table-hover align-middle mb-0"
+        >
+          <thead class="table-dark align-middle">
+            <tr>
+              <th scope="col">Livro/Autor</th>
+              <th scope="col">Usuário</th>
+              <th scope="col">Solicitado em</th>
+              <th scope="col">Devolução Prevista</th>
+              <th scope="col">Status</th>
+              <th scope="col" class="text-center">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="l in loans" :key="l.id">
+              <td>
+                <strong>{{ l.book?.title }}</strong>
+                <br />
+                <span class="small text-muted">{{ l.book?.author }}</span>
+              </td>
+              <td>
+                {{ l.user?.name }}
+                <br />
+                <span class="small text-muted">{{ l.user?.email }}</span>
+              </td>
+              <td>{{ formatDate(l.created_at) }}</td>
+
+              <td>
+                <template v-if="l.status === 'borrowed' || l.status === 'late'">
+                  {{ formatDate(l.due_date) }}
+                </template>
+                <template v-else-if="l.status === 'returned'">
+                  {{ formatDate(l.returned_at) }}
+                </template>
+                <template v-else> - </template>
+              </td>
+              <td>
+                <span :class="['badge', statusBadge(l.status)]">
+                  {{ statusLabel(l.status) }}
+                </span>
+              </td>
+              <td class="text-center text-nowrap">
+                <div v-if="l.status === 'requested'">
+                  <button
+                    class="btn btn-sm btn-success me-2"
+                    :disabled="loadingAction"
+                    @click="approveRequest(l.id)"
+                  >
+                    <i class="bi bi-check-circle me-1"></i> Aprovar
+                  </button>
+                  <button
+                    class="btn btn-sm btn-danger"
+                    :disabled="loadingAction"
+                    @click="rejectRequest(l.id)"
+                  >
+                    <i class="bi bi-x-circle me-1"></i> Rejeitar
+                  </button>
+                </div>
+
+                <button
+                  v-else-if="l.status === 'borrowed' || l.status === 'late'"
+                  class="btn btn-sm btn-outline-success"
+                  :disabled="loadingAction"
+                  @click="returnLoan(l.id)"
+                >
+                  <i class="bi bi-box-arrow-in-down me-1"></i> Devolver
+                </button>
+
+                <span v-else class="text-muted small fst-italic"
+                  >Sem ações</span
+                >
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div v-else class="alert alert-warning text-center m-2" role="alert">
+          Nenhum empréstimo encontrado.
+        </div>
+      </div>
+
+      <div
+        v-if="meta.total && totalPages > 1"
+        class="d-flex justify-content-between align-items-center mt-3"
+      >
+        <span class="text-muted"
+          >Página {{ meta.page }} de {{ totalPages }} (Total:
+          {{ meta.total }})</span
+        >
+
+        <div class="btn-group" role="group">
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            :disabled="!meta.has_prev"
+            @click="prev"
+          >
+            &laquo; Anterior
+          </button>
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            :disabled="!meta.has_next"
+            @click="next"
+          >
+            Próxima &raquo;
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="error" class="alert alert-danger mt-4" role="alert">
+      <strong>Erro:</strong> {{ error }}
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref, computed, onMounted } from 'vue'
+  // Presumindo que você tem um arquivo para serviços de Toast e Data
+  import { LoansService } from '@/services/loans.services'
+  import {
+    success as successToast,
+    error as errorToast,
+    confirm as confirmToast,
+  } from '@/composables/useToast'
+  import { useDate } from '@/composables/useDate'
+
+  const { formatDate } = useDate()
+
+  const loans = ref([])
+  const loading = ref(false)
+  const loadingAction = ref(false)
+  const error = ref(null)
+  const statusFilter = ref('')
+  const searchFilter = ref('') // Novo filtro de busca
+
+  const page = ref(1)
+  const limit = ref(10)
+  const meta = ref({ total: 0 })
+
+  const totalPages = computed(() => meta.value.total_pages || 1)
+
+  // Funções de Status (Reaproveitadas do componente original)
+  function statusBadge(status) {
+    switch (status) {
+      case 'requested':
+        return 'bg-primary'
+      case 'borrowed':
+        return 'bg-success'
+      case 'returned':
+        return 'bg-secondary'
+      case 'late':
+        return 'bg-danger'
+      case 'canceled':
+        return 'bg-info'
+      case 'rejected':
+        return 'bg-dark'
+      default:
+        return 'bg-dark'
+    }
+  }
+
+  function statusLabel(status) {
+    return (
+      {
+        requested: 'Solicitado',
+        canceled: 'Cancelado',
+        borrowed: 'Emprestado',
+        returned: 'Devolvido',
+        rejected: 'Rejeitado',
+        late: 'Atrasado',
+      }[status] || status
+    )
+  }
+
+  // Lógica de carregamento (Usando LoansService.list)
+  async function load() {
+    loading.value = true
+    error.value = null
+
+    const offset = (page.value - 1) * limit.value
+
+    try {
+      // ATENÇÃO: Usando LoansService.list() para listar todos
+      const data = await LoansService.list(
+        offset,
+        limit.value,
+        searchFilter.value, // Passando o novo filtro de busca
+        statusFilter.value,
+      )
+      loans.value = data.loans || []
+      meta.value = data.meta || {
+        total_pages: 1,
+        has_next: false,
+        has_prev: false,
+      }
+    } catch (err) {
+      console.error('Erro ao carregar empréstimos', err)
+      error.value =
+        err?.response?.data?.detail ||
+        err?.message ||
+        'Erro desconhecido ao carregar empréstimos'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // --- Funções Administrativas de Ação ---
+
+  async function approveRequest(id) {
+    const ok = await confirmToast('Confirmar aprovação deste empréstimo?', {
+      title: 'Aprovar Solicitação',
+      icon: 'question',
+    })
+    if (!ok) return
+
+    loadingAction.value = true
+    try {
+      await LoansService.approve(id) // Chamada para o novo endpoint 'approve'
+      successToast('Empréstimo aprovado e livro emprestado!')
+      load()
+    } catch (err) {
+      console.error(err)
+      errorToast(
+        err?.response?.data?.detail || 'Erro ao aprovar a solicitação.',
+      )
+    } finally {
+      loadingAction.value = false
+    }
+  }
+
+  async function rejectRequest(id) {
+    const ok = await confirmToast(
+      'Deseja rejeitar este pedido de empréstimo?',
+      {
+        title: 'Rejeitar Solicitação',
+        icon: 'warning',
+      },
+    )
+    if (!ok) return
+
+    loadingAction.value = true
+    try {
+      await LoansService.reject(id) // Chamada para o novo endpoint 'reject'
+      successToast('Solicitação rejeitada com sucesso.')
+      load()
+    } catch (err) {
+      console.error(err)
+      errorToast(
+        err?.response?.data?.detail || 'Erro ao rejeitar a solicitação.',
+      )
+    } finally {
+      loadingAction.value = false
+    }
+  }
+
+  async function returnLoan(id) {
+    const ok = await confirmToast('Confirmar devolução deste livro?', {
+      title: 'Devolver Livro',
+    })
+    if (!ok) return
+    loadingAction.value = true
+    try {
+      await LoansService.return(id)
+      successToast('Livro devolvido e estoque atualizado com sucesso.')
+      load()
+    } catch (err) {
+      console.error(err)
+      errorToast(
+        err?.response?.data?.detail || 'Erro ao registrar a devolução.',
+      )
+    } finally {
+      loadingAction.value = false
+    }
+  }
+  // ----------------------------------------
+
+  function reload() {
+    page.value = 1
+    load()
+  }
+
+  function next() {
+    if (meta.value.has_next) {
+      page.value++
+      load()
+    }
+  }
+
+  function prev() {
+    if (meta.value.has_prev) {
+      page.value--
+      load()
+    }
+  }
+
+  onMounted(load)
+</script>

--- a/src/pages/library/loans/MyLoansList.vue
+++ b/src/pages/library/loans/MyLoansList.vue
@@ -1,0 +1,303 @@
+<template>
+  <div class="container m-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Meus Empréstimos</h1>
+    </div>
+
+    <!-- Filtro de Estado -->
+    <div
+      class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4 p-3 border rounded bg-body border-secondary border-opacity-25"
+    >
+      <div class="mb-3 mb-md-0 d-flex align-items-center gap-2">
+        <label for="statusFilter" class="form-label fw-semibold mb-0"
+          >Filtrar por status:</label
+        >
+        <select
+          id="statusFilter"
+          v-model="statusFilter"
+          class="form-select form-select-sm w-auto"
+          @change="reload"
+        >
+          <option value="">Todos</option>
+          <option value="requested">Solicitado</option>
+          <option value="canceled">Cancelado</option>
+          <option value="borrowed">Emprestado</option>
+          <option value="returned">Devolvido</option>
+          <option value="late">Atrasado</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="alert alert-info text-center" role="alert">
+      <div class="spinner-border spinner-border-sm me-2" role="status">
+        <span class="visually-hidden">Carregando...</span>
+      </div>
+      Carregando...
+    </div>
+
+    <!-- Tabela -->
+    <div v-else>
+      <div v-if="!error" class="table-responsive shadow-sm rounded mb-4">
+        <table
+          v-if="loans.length"
+          class="table table-striped table-hover align-middle mb-0"
+        >
+          <thead class="table-dark align-middle">
+            <tr>
+              <th scope="col">Livro/Autor</th>
+              <th scope="col">Solicitado em</th>
+              <th scope="col">Devolução</th>
+              <th scope="col">Status</th>
+              <th scope="col" class="text-center">Ação</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="l in loans" :key="l.id">
+              <td>
+                <strong>{{ l.book?.title }}</strong>
+                <br />
+                <span class="small text-muted">{{ l.book?.author }}</span>
+              </td>
+              <td>{{ formatDate(l.created_at) }}</td>
+
+              <!-- Data dinâmica -->
+              <td>
+                <template v-if="l.status === 'returned'">
+                  {{ formatDate(l.returned_at) }}
+                </template>
+                <template v-else-if="l.status === 'borrowed'">
+                  {{ formatDate(l.due_date) }}
+                </template>
+                <template v-else> - </template>
+              </td>
+              <td>
+                <span :class="['badge', statusBadge(l.status)]">
+                  {{ statusLabel(l.status) }}
+                </span>
+              </td>
+              <td class="text-center text-nowrap">
+                <!-- Estado: requested -->
+                <button
+                  v-if="l.status === 'requested'"
+                  class="btn btn-sm btn-outline-danger"
+                  :disabled="loadingAction"
+                  @click="cancelRequest(l.id)"
+                >
+                  <i class="bi bi-x-circle me-1"></i> Cancelar
+                </button>
+
+                <!-- Estado: borrowed -->
+                <button
+                  v-else-if="l.status === 'borrowed'"
+                  class="btn btn-sm btn-outline-success"
+                  :disabled="loadingAction"
+                  @click="returnLoan(l.id)"
+                >
+                  <i class="bi bi-box-arrow-in-down me-1"></i> Devolver
+                </button>
+
+                <!-- Estado: late -->
+                <button
+                  v-else-if="l.status === 'late'"
+                  class="btn btn-sm btn-outline-warning"
+                  :disabled="loadingAction"
+                  @click="returnLoan(l.id)"
+                >
+                  <i class="bi bi-exclamation-triangle me-1"></i> Devolver
+                  (Atraso)
+                </button>
+
+                <!-- Estado: returned -->
+                <span v-else class="text-muted small fst-italic"
+                  >Sem ações</span
+                >
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div v-else class="alert alert-warning text-center m-2" role="alert">
+          Nenhum empréstimo encontrado.
+        </div>
+      </div>
+
+      <!-- Paginação -->
+      <div
+        v-if="meta.total && totalPages > 1"
+        class="d-flex justify-content-between align-items-center"
+      >
+        <span class="text-muted"
+          >Página {{ meta.page }} de {{ totalPages }}</span
+        >
+
+        <div class="btn-group" role="group">
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            :disabled="!meta.has_prev"
+            @click="prev"
+          >
+            &laquo; Anterior
+          </button>
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            :disabled="!meta.has_next"
+            @click="next"
+          >
+            Próxima &raquo;
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Erro -->
+    <div v-if="error" class="alert alert-danger mt-4" role="alert">
+      <strong>Erro:</strong> {{ error }}
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref, computed, onMounted } from 'vue'
+  import { LoansService } from '@/services/loans.services'
+  import {
+    success as successToast,
+    error as errorToast,
+    confirm as confirmToast,
+  } from '@/composables/useToast'
+  import { useDate } from '@/composables/useDate'
+
+  const { formatDate } = useDate()
+
+  const loans = ref([])
+  const loading = ref(false)
+  const loadingAction = ref(false)
+  const error = ref(null)
+  const statusFilter = ref('')
+
+  const page = ref(1)
+  const limit = ref(10)
+  const meta = ref({ total: 0 })
+
+  const totalPages = computed(() => meta.value.total_pages || 1)
+
+  function statusBadge(status) {
+    switch (status) {
+      case 'requested':
+        return 'bg-primary'
+      case 'borrowed':
+        return 'bg-success'
+      case 'returned':
+        return 'bg-secondary'
+      case 'late':
+        return 'bg-danger'
+      case 'canceled':
+        return 'bg-info'
+      case 'rejected':
+        return 'bg-dark'
+      default:
+        return 'bg-dark'
+    }
+  }
+
+  function statusLabel(status) {
+    return (
+      {
+        requested: 'Solicitado',
+        canceled: 'Cancelado',
+        borrowed: 'Emprestado',
+        returned: 'Devolvido',
+        rejected: 'Rejeitado',
+        late: 'Atrasado',
+      }[status] || status
+    )
+  }
+
+  async function load() {
+    loading.value = true
+    error.value = null
+
+    const offset = (page.value - 1) * limit.value
+
+    try {
+      const data = await LoansService.listMy(
+        offset,
+        limit.value,
+        statusFilter.value,
+      )
+      loans.value = data.loans || []
+      meta.value = data.meta || {
+        total_pages: 1,
+        has_next: false,
+        has_prev: false,
+      }
+    } catch (err) {
+      console.error('Erro ao carregar empréstimos', err)
+      error.value =
+        err?.response?.data?.detail ||
+        err?.message ||
+        'Erro desconhecido ao carregar empréstimos'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function cancelRequest(id) {
+    const ok = await confirmToast('Deseja cancelar este pedido?', {
+      title: 'Cancelar Solicitação',
+    })
+    if (!ok) return
+    loadingAction.value = true
+    try {
+      await LoansService.cancel(id)
+      successToast('Solicitação cancelada com sucesso.')
+      load()
+    } catch (err) {
+      console.error(err)
+      errorToast('Erro ao cancelar solicitação.')
+    } finally {
+      loadingAction.value = false
+    }
+  }
+
+  async function returnLoan(id) {
+    const ok = await confirmToast('Confirmar devolução deste livro?', {
+      title: 'Devolver Livro',
+    })
+    if (!ok) return
+    loadingAction.value = true
+    try {
+      await LoansService.return(id)
+      successToast('Livro devolvido com sucesso.')
+      load()
+    } catch (err) {
+      console.error(err)
+      errorToast('Erro ao devolver livro.')
+    } finally {
+      loadingAction.value = false
+    }
+  }
+
+  function reload() {
+    page.value = 1
+    load()
+  }
+
+  function next() {
+    if (meta.value.has_next) {
+      page.value++
+      load()
+    }
+  }
+
+  function prev() {
+    if (meta.value.has_prev) {
+      page.value--
+      load()
+    }
+  }
+
+  onMounted(load)
+</script>

--- a/src/services/loans.services.js
+++ b/src/services/loans.services.js
@@ -1,0 +1,40 @@
+import api from './api'
+
+const ENDPOINT = '/api/v1/library'
+
+export const LoansService = {
+  request: (bookId) =>
+    api.post(ENDPOINT + '/loans' + `/${bookId}/request`).then((r) => r.data),
+  approve: (loanId) =>
+    api.patch(ENDPOINT + '/loans' + `/${loanId}/approve`).then((r) => r.data),
+  reject: (loanId) =>
+    api.patch(ENDPOINT + '/loans' + `/${loanId}/reject`).then((r) => r.data),
+  cancel: (loanId) =>
+    api.patch(ENDPOINT + '/loans' + `/${loanId}/cancel`).then((r) => r.data),
+  return: (loanId) =>
+    api.patch(ENDPOINT + '/loans' + `/${loanId}/return`).then((r) => r.data),
+  list(
+    offset = 0,
+    limit = 10,
+    search = '',
+    status = '',
+    sort_by = 'created_at',
+    sort_order = 'desc',
+  ) {
+    const params = { offset, limit, sort_by, sort_order }
+    if (search) params.search = search
+    if (status) params.status = status
+    return api.get(ENDPOINT + '/loans', { params }).then((r) => r.data)
+  },
+  listMy(
+    offset = 0,
+    limit = 10,
+    status = '',
+    sort_by = 'created_at',
+    sort_order = 'desc',
+  ) {
+    const params = { offset, limit, sort_by, sort_order }
+    if (status) params.status = status
+    return api.get(ENDPOINT + '/loans/my', { params }).then((r) => r.data)
+  },
+}


### PR DESCRIPTION
## Descrição

Adiciona as páginas e serviços restantes para o módulo de biblioteca:

### Páginas
- **Lista de Pedidos de Livros** (`requestList.vue`): Para usuários navegarem no acervo
- **Lista de Empréstimos do Usuário** (`MyLoansList.vue`): Para usuários verem seus empréstimos
- **Lista de Empréstimos - Admin** (`AdminLoansList.vue`): Para administradores gerenciarem todos os empréstimos

### Serviço
- **Serviço de Empréstimos** (`loans.services.js`): Implementa as operações de API para empréstimos

### Observação
Este PR complementa o PR anterior que já adicionou a navegação e as rotas para a biblioteca.