### PR TITLE
chore: publish to GHCR and bump version to 1.0.0

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,75 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/pedronora/internum-web
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+          labels: |
+            org.opencontainers.image.title=Internum Web
+            org.opencontainers.image.description=Internum frontend
+            org.opencontainers.image.vendor=Pedro Nora
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+
+      - name: Compute APP_VERSION
+        id: app_version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            APP_VERSION=${{ steps.app_version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN npm run build
 
 FROM nginx:1.27-alpine AS runtime
 
+ARG APP_VERSION=dev
 ENV VITE_API_BASE_URL=http://localhost:8000
+ENV APP_VERSION=$APP_VERSION
 
 COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY docker/nginx/40-env.sh /docker-entrypoint.d/40-env.sh

--- a/README.md
+++ b/README.md
@@ -44,29 +44,45 @@ npm run build
 npm run preview
 ```
 
-## 🐳 Docker (TrueNAS)
+## 🐳 Docker e GitHub Container Registry (GHCR)
 
-Build da imagem (usando a versão do `package.json`, tag: `internum-web:latest`):
+Build local da imagem (tag `ghcr.io/pedronora/internum-web:local`):
 
 ```bash
 npm run docker:build
 ```
 
-Rodar local para validação:
+A imagem de produção fica em **GHCR**: `ghcr.io/pedronora/internum-web`.
+
+- Tag de release: `:1.0.0` (imutável, usa-se em produção)
+- Tag de desenvolvimento: `:latest` e `:sha-<commit>`
+- O CI (`docker-publish.yaml`) publica `latest` nos merges para `main` e `X.Y.Z` quando uma tag `vX.Y.Z` é criada.
+
+Pull e execução local:
 
 ```bash
+docker pull ghcr.io/pedronora/internum-web:1.0.0
 docker run --rm -p 8080:80 \
   -e VITE_API_BASE_URL="https://api.seu-dominio.com" \
-  internum-web:latest
+  ghcr.io/pedronora/internum-web:1.0.0
 ```
 
 No TrueNAS (Apps):
 
-1. Publique a imagem em um registry (`ghcr.io`, `docker hub`, etc.).
+1. Use a imagem `ghcr.io/pedronora/internum-web:1.0.0` (pull direto, sem `docker save/load`).
 2. Crie o app usando essa imagem e exponha a porta `80` do container.
 3. Configure as variáveis de ambiente:
    - `VITE_API_BASE_URL`: URL da API backend.
 4. Ao alterar essa variável, basta reiniciar o app (não precisa rebuild da imagem).
+
+## 🏷️ Criar uma release
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+O CI publica a imagem com o rótulo da versão no GHCR.
 
 ## 📁 Estrutura do Projeto
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "internum-web",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "docker:build": "docker build -t internum-web:latest .",
+    "docker:build": "docker build -t ghcr.io/pedronora/internum-web:local .",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint:prettier:check": "prettier --check .",


### PR DESCRIPTION
Prepara o GitHub Container Registry:

- Versão do package.json: `0.0.0` → `1.0.0`
- Novo workflow `docker-publish.yaml`: publica `latest`+sha em merges para `main` e `X.Y.Z` em tags `v*` (PR apenas build)
- Dockerfile: `ARG APP_VERSION` injetado no env.js
- README: instruções de pull do GHCR e criação de release