### PR TITLE
feat(vacation): mark vacation directly from accrual list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — internum-web
+
+Todas as mudanças relevantes desta imagem serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
+e o versionamento segue o padrão [Semantic Versioning](https://semver.org/lang/pt-BR/).
+
+## [Unreleased]
+
+### Added
+
+- Botão "Marcar férias" em `AdminAccrualList.vue` para períodos concessivos: permite que
+  Admin/Coord registre o gozo diretamente (grant normal), sem solicitação prévia, ao lado
+  da venda de dias.
+
+## [1.0.0] - 2026-08-13
+
+### Added
+
+- Lançamento inicial da aplicação web (Vue 3 + Vite + Pinia + Vue Router).
+- Autenticação JWT com refresh automático de token (axios interceptors) e
+  rotas protegidas por role (`admin`, `coord`, `user`).
+- Módulos de usuários (CRUD, perfil, alteração de senha) e férias
+  (solicitações, concessões, consulta por setor).
+- Módulo da biblioteca (livros e empréstimos) com listagem, busca e paginação.
+- Módulo de avisos (notices) com marcação de leitura e contador de não lidos.
+- Módulo de pareceres jurídicos (legal briefs) com versionamento.
+- Tema claro/escuro persistido em `localStorage` e sistema de toasts.
+- Servido via Nginx com configuração de variáveis de ambiente em runtime
+  (`env.js` injetado pelo entrypoint `40-env.sh`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internum-web",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internum-web",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",

--- a/src/pages/vacation/AdminAccrualList.vue
+++ b/src/pages/vacation/AdminAccrualList.vue
@@ -133,6 +133,13 @@
               class="d-flex gap-2 flex-wrap mb-3"
             >
               <button
+                v-if="rhActions(period).includes('register')"
+                class="btn btn-sm btn-outline-success"
+                @click="openGrantModal(period, 'normal')"
+              >
+                <i class="bi bi-calendar-check me-1"></i> Marcar férias
+              </button>
+              <button
                 v-if="rhActions(period).includes('sell')"
                 class="btn btn-sm btn-outline-warning"
                 @click="openSellModal(period)"
@@ -248,25 +255,12 @@
       </div>
     </div>
 
-    <!-- Modal Gozo retroativo / Pagamento em dobro -->
+    <!-- Modal Marcar férias / Gozo retroativo / Pagamento em dobro -->
     <div class="modal fade" id="grantModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
-          <div
-            class="modal-header"
-            :class="
-              grantModalType === 'double_payment'
-                ? 'bg-danger text-white'
-                : 'bg-primary text-white'
-            "
-          >
-            <h5 class="modal-title">
-              {{
-                grantModalType === 'double_payment'
-                  ? 'Pagamento em dobro'
-                  : 'Gozo retroativo'
-              }}
-            </h5>
+          <div class="modal-header" :class="grantModalInfo.headerClass">
+            <h5 class="modal-title">{{ grantModalInfo.title }}</h5>
             <button
               type="button"
               class="btn-close btn-close-white"
@@ -324,11 +318,7 @@
               <button
                 type="submit"
                 class="btn"
-                :class="
-                  grantModalType === 'double_payment'
-                    ? 'btn-danger'
-                    : 'btn-primary'
-                "
+                :class="grantModalInfo.submitClass"
                 :disabled="submitting"
               >
                 <span
@@ -392,9 +382,32 @@
   const grantModalType = ref('retroactive')
   const grantForm = ref({ start_date: '', end_date: '', notes: '' })
 
+  const grantModalInfo = computed(() => {
+    if (grantModalType.value === 'double_payment') {
+      return {
+        title: 'Pagamento em dobro',
+        headerClass: 'bg-danger text-white',
+        submitClass: 'btn-danger',
+      }
+    }
+    if (grantModalType.value === 'normal') {
+      return {
+        title: 'Marcar férias',
+        headerClass: 'bg-success text-white',
+        submitClass: 'btn-success',
+      }
+    }
+    return {
+      title: 'Gozo retroativo',
+      headerClass: 'bg-primary text-white',
+      submitClass: 'btn-primary',
+    }
+  })
+
   function rhActions(period) {
     const actions = []
     if (period.status === 'concessive' && period.available_days > 0) {
+      actions.push('register')
       actions.push('sell')
     }
     if (period.status === 'expired') {


### PR DESCRIPTION
## Resumo
- **feat(vacation)**: botão "Marcar férias" em `AdminAccrualList.vue` para Admin/Coord registrar o gozo diretamente (grant normal) em períodos concessivos, ao lado da venda de dias.
- **chore**: `package-lock.json` sincronizado com o version 1.0.0 do `package.json`.
- **docs**: CHANGELOG criado.

## Commits
- feat(vacation): add mark-vacation action for admin/coord
- chore: sync package-lock version with package.json
- docs(changelog): document mark-vacation action