### PR TITLE
chore: publish to GHCR and bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todas as mudanças relevantes desta imagem serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
 e o versionamento segue o padrão [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
-## [Unreleased]
+## [1.1.0] - 2026-08-13
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internum-web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internum-web",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "internum-web",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release 1.1.0 do internum-web: botão "Marcar férias" para Admin/Coord. Bump de `package.json`/`package-lock.json` para 1.1.0 e CHANGELOG atualizado.