### PR TITLE
fix(auth): correct "Voltar ao login" link in forgot-password

### DIFF
--- a/src/pages/auth/ForgotPassword.vue
+++ b/src/pages/auth/ForgotPassword.vue
@@ -31,7 +31,7 @@
     </form>
 
     <div class="mt-3">
-      <router-link to="/login">Voltar ao login</router-link>
+      <router-link :to="{ name: 'Login' }">Voltar ao login</router-link>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Corrige o link de retorno ao login na página de esqueci a senha: troca o caminho hardcoded `/login` (que não existe e caía no catch-all NotFound) pela rota nomeada `Login` (`/auth/login`), mantendo consistência com `ResetPassword.vue`.