### PR TITLE
chore: publish to GHCR and bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Todas as mudanças relevantes desta imagem serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)
 e o versionamento segue o padrão [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [1.2.0] - 2026-08-19
+
+### Changed
+
+- Migração completa de Bootstrap/Bootstrap Icons para **Tailwind CSS v4**
+  (Vite plugin + tokens no `@theme` + classes do design system em `main.css`),
+  removendo o CDN externo e o preflight de terceiros.
+- **Nav reescrito** (`Nav.vue`): menus data-driven, drawer deslizante no mobile
+  (Teleport + scroll lock), barra desktop com hover/click fixa, navegação por
+  teclado (setas e Esc) e acessibilidade ARIA.
+- Inputs e selects consolidados nas classes `input-base`/`select-base`
+  (fim de ~48 strings inline duplicadas e dos `.input-base` scoped nas páginas
+  de auth).
+
+### Fixed
+
+- Estado `disabled` de inputs/selects no modo escuro agora usa tons escuros
+  (`dark:disabled:bg-slate-800`), em vez de manter fundo claro.
+- Prop `ariaHidden` do `Icon` passa a aceitar `Boolean`/`String` (elimina
+  warnings de prop inválida).
+
 ## [1.1.1] - 2026-08-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "internum-web",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "internum-web",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "internum-web",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release 1.2.0: migração Tailwind v4 + Nav reescrito. Bump de versão e CHANGELOG. Após o merge, a tag `v1.2.0` publicará a imagem semver no GHCR.