### PR TITLE
fix: login button no desktop e busca nos Meus Avisos

### DIFF
--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -187,7 +187,7 @@
           </li>
         </ul>
 
-        <div class="flex items-center gap-2">
+        <div class="ml-auto flex items-center gap-2">
           <router-link
             v-if="!isAuthenticated"
             class="btn-primary"

--- a/src/pages/notices/NoticesUser.vue
+++ b/src/pages/notices/NoticesUser.vue
@@ -4,11 +4,11 @@
       class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
     >
       <h1 class="text-2xl font-bold">Meus Avisos</h1>
-      <div class="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+      <div class="flex w-full items-center gap-2 sm:w-auto">
         <input
           v-model="searchQuery"
           type="text"
-          class="input-base max-w-[250px]"
+          class="input-base min-w-0 flex-1 sm:max-w-[250px]"
           placeholder="Pesquisar..."
           @keyup.enter="fetchAll"
         />


### PR DESCRIPTION
## Resumo

Dois ajustes de layout em telas reduzidas/estado deslogado.

## Mudanças

- **Nav (desktop, deslogado)**: botão `Login` alinhado à direita (a div da direita ganhou `ml-auto`; antes o `justify-between` com o `ul` de menus oculto deixava o botão colado à logo).
- **Meus Avisos**: wrapper da busca agora é sempre horizontal — input `flex-1 min-w-0` (ocupa a largura disponível no mobile) com os botões "Buscar" e atualizar ao lado; desktop mantém `max-w-[250px]`.

## Verificação

- [x] `npm run lint:eslint:check`
- [x] `npm run lint:prettier:check`
- [x] `npm run build`