### PR TITLE
fix(routes): enforce requiresPermission on LegalBriefsCreate and parent titles

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -42,7 +42,11 @@ const routes = [
         path: 'admin/criar',
         name: 'LegalBriefsCreate',
         component: () => import('@/pages/legalBriefs/Create.vue'),
-        meta: { requiresAuth: true, title: 'Criar Ementa - ' },
+        meta: {
+          requiresAuth: true,
+          requiresPermission: true,
+          title: 'Criar Ementa - ',
+        },
       },
       {
         path: 'admin/:id/editar',
@@ -59,7 +63,7 @@ const routes = [
   {
     path: '/biblioteca',
     component: () => import('@/pages/RouterLayout.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, title: 'Biblioteca - ' },
     children: [
       {
         path: 'admin/livros',
@@ -128,7 +132,7 @@ const routes = [
   {
     path: '/avisos',
     component: () => import('@/pages/RouterLayout.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, title: 'Avisos - ' },
     children: [
       {
         path: '',
@@ -186,7 +190,11 @@ const routes = [
   {
     path: '/usuarios',
     component: () => import('@/pages/RouterLayout.vue'),
-    meta: { requiresAuth: true, requiresPermission: true },
+    meta: {
+      requiresAuth: true,
+      requiresPermission: true,
+      title: 'Usuários - ',
+    },
     children: [
       {
         path: '',
@@ -235,7 +243,7 @@ const routes = [
   {
     path: '/ferias',
     component: () => import('@/pages/RouterLayout.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, title: 'Férias - ' },
     children: [
       {
         path: '',


### PR DESCRIPTION
## Resumo

Corrige a única rota de gestão fora do padrão do AGENTS.md e padroniza os títulos dos pais-wrapper.

## Alterações

- **`LegalBriefsCreate`** (`/ementas/admin/criar`): adicionado `requiresPermission: true` — única rota `admin/*` sem o guard (o módulo pai `/ementas` não tem guard no nível do módulo, então a filha precisa do próprio). Agora consistente com `LegalBriefEdit` e as demais rotas de gestão.
- **Pais-wrapper**: adicionado `meta.title` em `/biblioteca` (Biblioteca), `/avisos` (Avisos), `/usuarios` (Usuários) e `/ferias` (Férias) — mesmo padrão de `/ementas` e `/perfil`.

## Verificação

- [x] `npm run lint:prettier:check` passa
- [x] `npm run lint:eslint:check` passa
- [x] `npm run test` (62 testes) passa
- [x] `npm run build` passa