### PR TITLE
docs: update README and AGENTS to reflect rich content editor and routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,9 @@ src/
 │   ├── BaseSpinner.vue    # Loading spinner
 │   ├── BaseBadge.vue      # Badge (color: slate|dark|light|primary|success|warning|danger|info)
 │   ├── BasePagination.vue # Paginação (variant: simple|pages; emite prev/next/go)
-│   └── BaseModal.vue      # Modal com Teleport (tone: default|success|danger; slots header/default/footer)
+│   ├── BaseModal.vue      # Modal com Teleport (tone: default|success|danger; slots header/default/footer)
+│   ├── TiptapEditor.vue   # Editor de conteúdo rico (TipTap; emite HTML sanitizado)
+│   └── RichText.vue       # Renderização de HTML sanitizado (DOMPurify) — único local permitido de v-html
 ├── pages/
 │   ├── auth/              # Login, ForgotPassword, ResetPassword (public routes)
 │   ├── legalBriefs/       # List, Create, Update (admin/coord only)
@@ -351,16 +353,18 @@ onMounted(load)
 
 **Location:** `src/components/*.vue`
 
-| Component            | Responsibility                                                                        |
-| -------------------- | ------------------------------------------------------------------------------------- |
-| `Nav.vue`            | Top navbar, role-based menus, user dropdown, theme toggle, unread notice badge        |
-| `Footer.vue`         | Static footer                                                                         |
-| `Toasts.vue`         | Renders `toastStore.toasts` as Tailwind toasts (auto-dismiss, actions)                |
-| `Icon.vue`           | Ícones SVG inline pelo nome (`search`, `plus-lg`, `trash`, etc.)                      |
-| `BaseSpinner.vue`    | Loading spinner reutilizável                                                          |
-| `BaseBadge.vue`      | Badge com `color` + `variant` (solid/soft)                                            |
-| `BasePagination.vue` | Paginação `simple`/`pages` a partir de `meta` (page, total_pages, has_prev, has_next) |
-| `BaseModal.vue`      | Modal com Teleport, `tone` (default/success/danger), slots header/default/footer      |
+| Component            | Responsibility                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| `Nav.vue`            | Top navbar, role-based menus, user dropdown, theme toggle, unread notice badge                   |
+| `Footer.vue`         | Static footer                                                                                    |
+| `Toasts.vue`         | Renders `toastStore.toasts` as Tailwind toasts (auto-dismiss, actions)                           |
+| `Icon.vue`           | Ícones SVG inline pelo nome (`search`, `plus-lg`, `trash`, etc.)                                 |
+| `BaseSpinner.vue`    | Loading spinner reutilizável                                                                     |
+| `BaseBadge.vue`      | Badge com `color` + `variant` (solid/soft)                                                       |
+| `BasePagination.vue` | Paginação `simple`/`pages` a partir de `meta` (page, total_pages, has_prev, has_next)            |
+| `BaseModal.vue`      | Modal com Teleport, `tone` (default/success/danger), slots header/default/footer                 |
+| `TiptapEditor.vue`   | Editor de conteúdo rico (TipTap) — `v-model` emite HTML (a renderização é sempre via `RichText`) |
+| `RichText.vue`       | Renderiza HTML sanitizado com DOMPurify — **único componente autorizado a usar `v-html`**        |
 
 **Pattern:**
 
@@ -472,7 +476,7 @@ When an AI agent (Gemini, etc.) operates on this codebase, it MUST adhere to:
 - ❌ Importing stores/composables in `services/*.js`
 - ❌ Direct `axios` imports in components (use service layer)
 - ❌ Mutating props in child components
-- ❌ `v-html` without sanitization (ESLint warns)
+- ❌ `v-html` without sanitization (ESLint warns). Renderização de conteúdo rico **somente** via `<RichText>` (DOMPurify) e edição **somente** via `<TiptapEditor>`
 - ❌ Creating new state management solutions (use Pinia)
 - ❌ Custom CSS in `.vue` files (use `main.css`)
 
@@ -558,8 +562,8 @@ When an AI agent uses tools to modify this codebase, the following interface app
 
 ## 10. Version & Maintenance
 
-- **Document Version:** 1.0
-- **Last Updated:** 2026-08-04
+- **Document Version:** 1.1
+- **Last Updated:** 2026-08-20
 - **Maintained By:** Human + AI contributors
 - **Review Cycle:** Update when architecture patterns change (new libraries, structural refactors)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Aplicação frontend construída com **Vue 3** e **Vite** para o projeto Internu
 - Vue Router
 - Pinia
 - Axios
-- Bootstrap + Bootstrap Icons
+- Tailwind CSS (v4)
+- TipTap (editor de conteúdo rico)
+- DOMPurify (sanitização do HTML renderizado)
 - Vuelidate
 - Yup
 - ESLint + Prettier
@@ -54,22 +56,22 @@ npm run docker:build
 
 A imagem de produção fica em **GHCR**: `ghcr.io/pedronora/internum-web`.
 
-- Tag de release: `:1.0.0` (imutável, usa-se em produção)
+- Tag de release: `:1.3.0` (imutável, usa-se em produção)
 - Tag de desenvolvimento: `:latest` e `:sha-<commit>`
 - O CI (`docker-publish.yaml`) publica `latest` nos merges para `main` e `X.Y.Z` quando uma tag `vX.Y.Z` é criada.
 
 Pull e execução local:
 
 ```bash
-docker pull ghcr.io/pedronora/internum-web:1.0.0
+docker pull ghcr.io/pedronora/internum-web:1.3.0
 docker run --rm -p 8080:80 \
   -e VITE_API_BASE_URL="https://api.seu-dominio.com" \
-  ghcr.io/pedronora/internum-web:1.0.0
+  ghcr.io/pedronora/internum-web:1.3.0
 ```
 
 No TrueNAS (Apps):
 
-1. Use a imagem `ghcr.io/pedronora/internum-web:1.0.0` (pull direto, sem `docker save/load`).
+1. Use a imagem `ghcr.io/pedronora/internum-web:1.3.0` (pull direto, sem `docker save/load`).
 2. Crie o app usando essa imagem e exponha a porta `80` do container.
 3. Configure as variáveis de ambiente:
    - `VITE_API_BASE_URL`: URL da API backend.
@@ -78,8 +80,8 @@ No TrueNAS (Apps):
 ## 🏷️ Criar uma release
 
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+git tag v1.3.0
+git push origin v1.3.0
 ```
 
 O CI publica a imagem com o rótulo da versão no GHCR.
@@ -107,8 +109,16 @@ O CI publica a imagem com o rótulo da versão no GHCR.
 │   │   ├── main.css
 │   │   └── vue.svg
 │   ├── components
+│   │   ├── BaseBadge.vue
+│   │   ├── BaseModal.vue
+│   │   ├── BasePagination.vue
+│   │   ├── BaseSpinner.vue
 │   │   ├── Footer.vue
+│   │   ├── Icon.vue
+│   │   ├── iconPaths.js
 │   │   ├── Nav.vue
+│   │   ├── RichText.vue
+│   │   ├── TiptapEditor.vue
 │   │   └── Toasts.vue
 │   ├── composables
 │   │   ├── useCPF.js
@@ -175,6 +185,13 @@ O CI publica a imagem com o rótulo da versão no GHCR.
 │   │   ├── users.services.js
 │   │   ├── vacation.services.js
 │   │   └── __tests__
+│   │       ├── auth.services.test.js
+│   │       ├── books.services.test.js
+│   │       ├── home.services.test.js
+│   │       ├── legalBriefs.services.test.js
+│   │       ├── loans.services.test.js
+│   │       ├── notices.services.test.js
+│   │       ├── users.services.test.js
 │   │       └── vacation.services.test.js
 │   └── stores
 │       ├── auth.js


### PR DESCRIPTION
## Resumo

Atualização de documentação para refletir o trabalho recente — sem alteração de release (sem bump de versão/tag).

## Alterações

- **README.md**: tecnologias (Tailwind CSS, TipTap, DOMPurify no lugar de Bootstrap/Bootstrap Icons); tags GHCR `:1.0.0` → `:1.3.0`; árvore de estrutura completa (componentes `Icon`, `BaseSpinner`, `BaseBadge`, `BasePagination`, `BaseModal`, `TiptapEditor`, `RichText`, `iconPaths.js`) e todos os arquivos de teste de serviços.
- **AGENTS.md**: `TiptapEditor.vue`/`RichText.vue` na estrutura e tabela de componentes; regra reforçada: conteúdo rico só via `RichText` (DOMPurify), edição só via `TiptapEditor`; versão 1.1 / Last Updated 2026-08-20.